### PR TITLE
Add filters for schematics with unaffordable and non-placeable blocks

### DIFF
--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -87,13 +87,13 @@ function filtersDialog() {
             })).growX().left().pad(5);
             p.row();
             p.check(
-                "Hide schematics that cannot be placed",
+                "Placeable",
                 (checked) => setFilter("hideNotPlaceable", checked)
-            ).left().row();
+            ).left().row().pad(5);
             p.check(
-                "Hide unaffordable schematics",
+                "Affordable",
                 (checked) => setFilter("hideTooExpensive", checked)
-            ).left().row();
+            ).left().row().pad(5);
         })).grow();
     })).grow().pad(70);
     dialog.addCloseButton();

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -86,6 +86,14 @@ function filtersDialog() {
                 }).fill();
             })).growX().left().pad(5);
             p.row();
+            p.check(
+                "Hide schematics that cannot be placed",
+                (checked) => setFilter("hideNotPlaceable", checked)
+            ).left().row();
+            p.check(
+                "Hide unaffordable schematics",
+                (checked) => setFilter("hideTooExpensive", checked)
+            ).left().row();
         })).grow();
     })).grow().pad(70);
     dialog.addCloseButton();

--- a/scripts/filter.js
+++ b/scripts/filter.js
@@ -24,20 +24,7 @@ const placeableFilter = (schem) => (
         )
         .empty
 );
-const affordableFilter = (schem) => {
-    if (!filters.hideTooExpensive) {
-        return true;
-    }
-    const team = Vars.player.team();
-    if (!team) {
-        return true;
-    }
-    let affordable = true;
-    for (let item of schem.requirements().toArray()) {
-        affordable = affordable && team.items().get(item.item) >= item.amount;
-    }
-    return affordable;
-};
+const affordableFilter = (schem) => !filters.hideTooExpensive || Vars.player.team().items().has(schem.requirements());
 
 
 module.exports = {

--- a/scripts/filter.js
+++ b/scripts/filter.js
@@ -1,4 +1,10 @@
-const filters = { text: "", desc: "", planet: 0};
+const filters = {
+    text: "",
+    desc: "",
+    planet: 0,
+    hideNotPlaceable: false,
+    hideTooExpensive: false
+};
 
 const textFilter = (schem) => filters.text === "" || schem.name().toLowerCase().includes(filters.text.toLowerCase());
 const descFilter = (schem) => filters.desc === "" || schem.description().toLowerCase().includes(filters.desc.toLowerCase());
@@ -7,10 +13,35 @@ const planetFilter = (schem) => {
     let erekir = schem.requirements().toSeq().contains(boolf(i => Items.erekirItems.contains(i.item) && !Items.serpuloItems.contains(i.item)));
     return [1, serpulo && !erekir, !serpulo && erekir, serpulo && erekir][filters.planet] || false;
 };
+const placeableFilter = (schem) => (   
+    !filters.hideNotPlaceable
+    || schem.tiles.copy().filter(
+        (tile) => (!tile.block.isPlaceable()
+            || !tile.block.environmentBuildable())
+            // Sandbox-only blocks (sources and voids) are frequently used
+            // to indicate inputs and outputs, so ignore them.
+            && tile.block.buildVisibility != BuildVisibility.sandboxOnly
+        )
+        .empty
+);
+const affordableFilter = (schem) => {
+    if (!filters.hideTooExpensive) {
+        return true;
+    }
+    const team = Vars.player.team();
+    if (!team) {
+        return true;
+    }
+    let affordable = true;
+    for (let item of schem.requirements().toArray()) {
+        affordable = affordable && team.items().get(item.item) >= item.amount;
+    }
+    return affordable;
+};
 
 
 module.exports = {
-    filter: (schem) => textFilter(schem) && descFilter(schem) && planetFilter(schem),
+    filter: (schem) => textFilter(schem) && descFilter(schem) && planetFilter(schem) && placeableFilter(schem) && affordableFilter(schem),
     setFilter: (filter, value) => (filters[filter] = value),
     getFilter: (filter) => filters[filter]
 };


### PR DESCRIPTION
This adds two checkboxes to the filters dialog.

![image](https://github.com/eeve-lyn/schematic-browser/assets/141530305/cb2cec86-48da-4fbf-9816-e815ebd6505a)

The first hides schematics that cannot be placed because they contain blocks that are banned or for a different planet (it ignores sources and voids since they’re frequently used to show inputs and outputs). The second hides schematics that the player’s team doesn’t currently have enough resources to build.